### PR TITLE
feat: net8

### DIFF
--- a/src/components/tbc.core/tbc.core.csproj
+++ b/src/components/tbc.core/tbc.core.csproj
@@ -11,8 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="MessagePack" Version="2.4.59" />
-      <PackageReference Include="Refit" Version="6.3.2" />
+      <PackageReference Include="MessagePack" Version="2.5.140" />
+      <PackageReference Include="Refit" Version="7.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/components/tbc.host/Components/SourceGeneratorResolver/SourceGeneratorResolver.cs
+++ b/src/components/tbc.host/Components/SourceGeneratorResolver/SourceGeneratorResolver.cs
@@ -68,7 +68,7 @@ public class SourceGeneratorResolver : ComponentBase<SourceGeneratorResolver>, I
                 Diags: ImmutableDictionary.Create<string, object>());
         }
 
-        var searches = new[] { "roslyn4.0/cs", "roslyn4.0\\cs", "analyzers/dotnet/cs", "analyzers\\dotnet\\cs" };
+        var searches = new[] { "roslyn4.0/cs", "roslyn4.0\\cs", "analyzers/dotnet/cs", "analyzers\\dotnet\\cs", "analyzers/dotnet/roslyn4.0", "analyzers\\dotnet\\roslyn4.0", };
 
         var nugetPath = _fileSystem.Path.Combine(GetNugetPackageCachePath, package, version);
         var dllPaths = _fileSystem.Directory.GetFiles(nugetPath, "*.dll", SearchOption.AllDirectories)

--- a/src/components/tbc.host/tbc.host.csproj
+++ b/src/components/tbc.host/tbc.host.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RootNamespace>Tbc.Host</RootNamespace>
         <LangVersion>preview</LangVersion>        
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -15,19 +15,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.1.0" />
-        <PackageReference Include="IgnoresAccessChecksToGenerator" Version="0.6.0" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-        <PackageReference Include="NuGet.Configuration" Version="6.4.0" />
-        <PackageReference Include="OneOf" Version="3.0.223" />
+        <PackageReference Include="DryIoc.Microsoft.DependencyInjection" Version="6.2.0" />
+        <PackageReference Include="IgnoresAccessChecksToGenerator" Version="0.7.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="NuGet.Configuration" Version="6.9.1" />
+        <PackageReference Include="OneOf" Version="3.0.263" />
         <PackageReference Include="RxFileSystemWatcher" Version="1.0.0" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20303.1" />
-        <PackageReference Include="System.IO.Abstractions" Version="19.1.5" />
+        <PackageReference Include="System.IO.Abstractions" Version="20.0.15" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-        <PackageReference Include="System.Reactive.Compatibility" Version="5.0.0" />
+        <PackageReference Include="System.Reactive.Compatibility" Version="6.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/components/tbc.target/tbc.target.csproj
+++ b/src/components/tbc.target/tbc.target.csproj
@@ -18,10 +18,10 @@
 
     <ItemGroup>
         <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
-        <PackageReference Include="Polly" Version="7.2.3" />
-        <PackageReference Include="System.Reactive" Version="5.0.0" />
-        <PackageReference Include="System.Text.Json" Version="7.0.1" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+        <PackageReference Include="Polly" Version="8.3.1" />
+        <PackageReference Include="System.Reactive" Version="6.0.0" />
+        <PackageReference Include="System.Text.Json" Version="8.0.2" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>
 
 </Project>

--- a/src/heads/tbc.host.console/tbc.host.console.csproj
+++ b/src/heads/tbc.host.console/tbc.host.console.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net7.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/test/TestSocketTarget/TestSocketTarget.csproj
+++ b/src/test/TestSocketTarget/TestSocketTarget.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Targets net8 and bumps all dependencies to latest. Notably bumps Roslyn, so tbc supports new language features like primary constructors and collection expressions.